### PR TITLE
Introduce PUNCH_MY_PATH frame for multipath

### DIFF
--- a/draft-seemann-quic-nat-traversal.md
+++ b/draft-seemann-quic-nat-traversal.md
@@ -202,7 +202,7 @@ which may result in the creation or migration of as many paths.
 If the server receives a PUNCH_ME_NOW frame after the QUIC Multipath extensions
 have been negotiated, it MUST treat it as PUNCH_MY_PATH frame carrying Path ID 0.
 
-When QUIC Multipath extensions is been negotiated, the probing of new
+When the QUIC Multipath extensions have been negotiated, the probing of new
 path will be limited by the availability of connection identifiers
 for new Path IDs. Endpoints SHOULD set Path ID limits high enough to allow
 for the desired number of concurrent path validation attempts.

--- a/draft-seemann-quic-nat-traversal.md
+++ b/draft-seemann-quic-nat-traversal.md
@@ -341,7 +341,7 @@ frame, except for the addition of the Path-Id element:
 
 Path ID:
 
-: The path Id selected by the client for the new path.
+: The Path ID selected by the client for the new path.
 
 PUNCH_MY_PATH frames are ack-eliciting.
 


### PR DESCRIPTION
I looked at what if would take to support multipath. I used a new frame for "PUNCH_ME_NOW + Path ID", but if we could have a bit in the PUNCH_ME_NOW frame type we would not need that. We would need some explanation about how to use the Path ID, which I added in a subsection of PUNCH_ME_NOW.

I expect this text to evolve after discussions. But I would like to have these discussions.

Close #30